### PR TITLE
Fixed full screen toggling issue. Minor overlay render improvement.

### DIFF
--- a/Helium/AppDelegate.swift
+++ b/Helium/AppDelegate.swift
@@ -50,6 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func handleProximityEntry(_ event: NSEvent) {
         helium.lastUsedTablet.val = event.systemTabletID
         helium.showOverlay()
+        helium.penIsProximate = true
     }
 
     /** When tablet pen exits proximity */
@@ -61,6 +62,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         helium.hideOverlay()
+        helium.penIsProximate = false
     }
 
     /** Handles .tabletProximity events. */

--- a/Helium/Helium.swift
+++ b/Helium/Helium.swift
@@ -16,6 +16,7 @@ class Helium: Store {
     var mode: Mode
     var lastUsedTablet = Ref(0) // initialize with invalid tablet ID
     private let overlay: Overlay
+    var penIsProximate: Bool = false
 
     override init() {
         self.showBounds = Pair(on: "Hide Bounds", off: "Show Bounds", true)
@@ -29,6 +30,7 @@ class Helium: Store {
     func hideOverlay() { overlay.hide() }
     func toggleMode() { mode.next(); refresh() }
     func refresh() { mode == .precision ? setPrecisionMode() : setFullScreenMode() }
+    func toggleBounds() { self.showBounds.toggle(); hideOverlay(); showOverlay(); }
 
     /** Make the tablet cover the area around the cursor's current location. */
     func setPrecisionMode() { setPrecisionMode(at: NSEvent.mouseLocation) }
@@ -40,14 +42,18 @@ class Helium: Store {
         let area = screen.precision(at: point, scale: scale, aspectRatio: aspectRatio)
         setTablet(to: area)
         moveOverlay(to: area)
-        overlay.flash()
+        
+        if penIsProximate {
+            overlay.show()
+        } else {
+            overlay.flash()
+        }
     }
 
     /** Make the tablet cover the whole screen. */
     func setFullScreenMode() {
         mode = .fullscreen
-        let screen = NSRect.screen()
-        let area = screen.fill(withAspectRatio: aspectRatio)
+        let area = NSRect.primaryScreen()
         setTablet(to: area)
         overlay.fullscreen(to: area, lineColor: lineColor, lineWidth: lineWidth, cornerLength: cornerLength)
         overlay.flash()

--- a/Helium/MenuBar.swift
+++ b/Helium/MenuBar.swift
@@ -59,7 +59,7 @@ class MenuBar {
         prefsWindowController?.showWindow(self)
     }
 
-    @objc func toggleBounds() { helium.showBounds.toggle(); update() }
+    @objc func toggleBounds() { helium.toggleBounds(); update() }
     @objc func toggleMode() { helium.toggleMode(); update() }
     @objc func setPrecisionMode() { helium.setPrecisionMode(); update() }
     @objc func setFullScreenMode() { helium.setFullScreenMode(); update() }

--- a/Helium/Rekt.swift
+++ b/Helium/Rekt.swift
@@ -21,6 +21,10 @@ extension NSRect {
         size.height = width / ratio
         origin = NSPoint(x: parent.midX, y: parent.midY)
     }
+    
+    static func primaryScreen() -> Self {
+            return NSScreen.main!.frame
+    }
 
     /** Scales a rect. Origin is invariant. */
     mutating func scale(by x: Double) { size.width *= x; size.height *= x }


### PR DESCRIPTION
Hi @nguyenvukhang !

This is a really useful app you created. I use it because the original precise screen is too small and not customizable and my widescreen is too unproportional to my tablet.

But toggling back to full screen did not work for me resulting in the situation in the picture.

![image](https://github.com/nguyenvukhang/helium/assets/5748886/e7670a57-525f-44e5-bef2-7b422c619d8e)

This PR fixes incorrect behavior, at least on my MacOS 14.4.1 with an external display. There are also some minor changes to make bound's appearance more consistent.

I have zero experience with Swift so I'm open to your comments and suggestions.

Thanks again for the app!